### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/bin/readability
+++ b/bin/readability
@@ -2,7 +2,7 @@
 
 var program = require('commander')
   , read = require('node-readability')
-  , ent = require('ent')
+  , he = require('he')
   , pkg = require('../package.json')
   , clc = require('cli-color');
 
@@ -27,7 +27,7 @@ if(program.color) {
 var error = function(msg) {
   if(msg) console.log(clc.red("Error: ")+msg);
   console.log();
-  usage(); 
+  usage();
   process.exit(0);
 }
 
@@ -63,12 +63,12 @@ read(url, function(err, article, meta) {
   content = content.replace(/ {2,*}|\t/g,' ');
 
   var content = content.replace(/<\/?[^>]+(>|$)/g, "");
-  content = ent.decode(content);
+  content = he.decode(content);
   console.log(content);
 
   // The raw HTML code of the page
   //console.log(article.html);
   // The document object of the page
   //console.log(article.document);
-  
+
 });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "node-readability": "~0.3.2",
     "cli-color": "~0.2.3",
-    "ent": "~0.1.0",
+    "he": "~0.4.1",
     "commander": "~2.1.0"
   }
 }


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
